### PR TITLE
Ensure scripts module is packaged

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,10 @@ name = "gpt-dev-test"
 version = "0.1.0"
 description = "Projeto de testes com ChatGPT, VSCode, GitHub e Poetry"
 authors = ["Israel Monteiro <israel.santosmonteiro@gmail.com>"]
-packages = [{ include = "src" }]
+packages = [
+    { include = "src" },
+    { include = "scripts" }
+]
 
 [tool.poetry.dependencies]
 python = "^3.11"


### PR DESCRIPTION
## Summary
- include the `scripts` directory in the package configuration
- make `scripts` importable by adding `__init__.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6882fb01b97c83319c697c6c85c94262